### PR TITLE
drivers/atrf2xx: remove `at86rf2xx_reset_state_machine`

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -56,7 +56,9 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     at86rf2xx_hardware_reset(dev);
 
     /* Reset state machine to ensure a known state */
-    at86rf2xx_reset_state_machine(dev);
+    if (dev->state == AT86RF2XX_STATE_P_ON) {
+        at86rf2xx_set_state(dev, AT86RF2XX_STATE_FORCE_TRX_OFF);
+    }
 
     /* reset options and sequence number */
     dev->netdev.seq = 0;

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -498,17 +498,3 @@ uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
 
     return old_state;
 }
-
-void at86rf2xx_reset_state_machine(at86rf2xx_t *dev)
-{
-    uint8_t old_state;
-
-    at86rf2xx_assert_awake(dev);
-
-    /* Wait for any state transitions to complete before forcing TRX_OFF */
-    do {
-        old_state = at86rf2xx_get_status(dev);
-    } while (old_state == AT86RF2XX_STATE_IN_PROGRESS);
-
-    at86rf2xx_set_state(dev, AT86RF2XX_STATE_FORCE_TRX_OFF);
-}

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -392,17 +392,6 @@ void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state);
 uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state);
 
 /**
- * @brief   Reset the internal state machine to TRX_OFF mode.
- *
- * This will force a transition to TRX_OFF regardless of whether the transceiver
- * is currently busy sending or receiving. This function is used to get back to
- * a known state during driver initialization.
- *
- * @param[in] dev           device to operate on
- */
-void at86rf2xx_reset_state_machine(at86rf2xx_t *dev);
-
-/**
  * @brief   Convenience function for simply sending data
  *
  * @note This function ignores the PRELOADING option


### PR DESCRIPTION
This function was only used once in the initialization procedure.
Inlining the actual state change reduces overhead and lines to
maintain.

If ever needed, undo this commit.