### PR TITLE
Make RIOT compatible with the latest openthread

### DIFF
--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -3,7 +3,11 @@ EDBG ?= $(RIOT_EDBG)
 FLASHER ?= $(EDBG)
 OFLAGS ?= -O binary
 HEXFILE = $(ELFFILE:.elf=.bin)
-FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -e -v -p -f $(HEXFILE)
+ifeq ($(SERIAL_NUMBER),)
+  FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -e -v -p -f $(HEXFILE)
+else
+  FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -e -v -p -f $(HEXFILE) -s $(SERIAL_NUMBER)
+endif
 
 ifeq ($(RIOT_EDBG),$(FLASHER))
   FLASHDEPS += $(RIOT_EDBG)

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
-PKG_VERSION=8dc31d6e279d4f04fa64b5357d96e1ed20f4967a
+PKG_VERSION=5128602b4950c31425e3c30244cfc889f7bc2789
 PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 
 ifneq (,$(filter openthread-cli-ftd,$(USEMODULE)))

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
-PKG_VERSION=529c291f7a0cab3715e9b13887c536baa402f488
+PKG_VERSION=fc72e4e7197f595a6e1d6a43dd5811c3bc260db0
 PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 
 ifneq (,$(filter openthread-cli-ftd,$(USEMODULE)))

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
-PKG_VERSION=5128602b4950c31425e3c30244cfc889f7bc2789
+PKG_VERSION=529c291f7a0cab3715e9b13887c536baa402f488
 PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 
 ifneq (,$(filter openthread-cli-ftd,$(USEMODULE)))

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
-PKG_VERSION=fc72e4e7197f595a6e1d6a43dd5811c3bc260db0
+PKG_VERSION=f77321ac9c6a20d1269e42287f40aae62be875ec
 PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 
 ifneq (,$(filter openthread-cli-ftd,$(USEMODULE)))

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
-PKG_VERSION=f77321ac9c6a20d1269e42287f40aae62be875ec
+PKG_VERSION=b182d8d0463974dc541c00bbd5d11ae64920bbf0
 PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 
 ifneq (,$(filter openthread-cli-ftd,$(USEMODULE)))

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -70,7 +70,7 @@ static void *_openthread_event_loop(void *arg) {
     otPlatUartEnable();
 
     /* init OpenThread */
-    sInstance = otInstanceInit();
+    sInstance = otInstanceInitSingle();
 
     msg_init_queue(_queue, OPENTHREAD_QUEUE_LEN);
     netdev_t *dev;

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -24,7 +24,7 @@
 #include "openthread/cli.h"
 #include "openthread/instance.h"
 #include "openthread/ip6.h"
-#include "openthread/platform/alarm.h"
+#include "openthread/platform/alarm-milli.h"
 #include "openthread/platform/uart.h"
 #include "openthread/tasklet.h"
 #include "openthread/thread.h"
@@ -106,7 +106,7 @@ static void *_openthread_event_loop(void *arg) {
             switch (msg.type) {
                 case OPENTHREAD_XTIMER_MSG_TYPE_EVENT:
                     /* Tell OpenThread a time event was received */
-                    otPlatAlarmFired(sInstance);
+                    otPlatAlarmMilliFired(sInstance);
                     break;
                 case OPENTHREAD_NETDEV_MSG_TYPE_EVENT:
                     /* Received an event from driver */

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -18,7 +18,6 @@
 
 #include <assert.h>
 
-#include "openthread/platform/alarm.h"
 #include "openthread/platform/uart.h"
 #include "ot.h"
 #include "random.h"

--- a/pkg/openthread/contrib/platform_alarm.c
+++ b/pkg/openthread/contrib/platform_alarm.c
@@ -19,7 +19,7 @@
 #include <stdint.h>
 
 #include "msg.h"
-#include "openthread/platform/alarm.h"
+#include "openthread/platform/alarm-milli.h"
 #include "ot.h"
 #include "thread.h"
 #include "xtimer.h"
@@ -38,9 +38,9 @@ static msg_t ot_alarm_msg;
  * @param[in] aT0        The reference time.
  * @param[in] aDt        The time delay in milliseconds from @p aT0.
  */
-void otPlatAlarmStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
+void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
-    DEBUG("openthread: otPlatAlarmStartAt: aT0: %" PRIu32 ", aDT: %" PRIu32 "\n", aT0, aDt);
+    DEBUG("openthread: otPlatAlarmMilliStartAt: aT0: %" PRIu32 ", aDT: %" PRIu32 "\n", aT0, aDt);
     ot_alarm_msg.type = OPENTHREAD_XTIMER_MSG_TYPE_EVENT;
 
     if (aDt == 0) {
@@ -53,16 +53,16 @@ void otPlatAlarmStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 }
 
 /* OpenThread will call this to stop alarms */
-void otPlatAlarmStop(otInstance *aInstance)
+void otPlatAlarmMilliStop(otInstance *aInstance)
 {
-    DEBUG("openthread: otPlatAlarmStop\n");
+    DEBUG("openthread: otPlatAlarmMilliStop\n");
     xtimer_remove(&ot_timer);
 }
 
 /* OpenThread will call this for getting running time in millisecs */
-uint32_t otPlatAlarmGetNow(void)
+uint32_t otPlatAlarmMilliGetNow(void)
 {
     uint32_t now = xtimer_now_usec() / US_PER_MS;
-    DEBUG("openthread: otPlatAlarmGetNow: %" PRIu32 "\n", now);
+    DEBUG("openthread: otPlatAlarmMilliGetNow: %" PRIu32 "\n", now);
     return now;
 }

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -266,12 +266,12 @@ void otPlatRadioSetPanId(otInstance *aInstance, uint16_t panid)
 }
 
 /* OpenThread will call this for setting extended address */
-void otPlatRadioSetExtendedAddress(otInstance *aInstance, uint8_t *aExtendedAddress)
+void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtendedAddress)
 {
     DEBUG("openthread: otPlatRadioSetExtendedAddress\n");
     uint8_t reversed_addr[IEEE802154_LONG_ADDRESS_LEN];
     for (int i = 0; i < IEEE802154_LONG_ADDRESS_LEN; i++) {
-        reversed_addr[i] = aExtendedAddress[IEEE802154_LONG_ADDRESS_LEN - 1 - i];
+        reversed_addr[i] = aExtendedAddress->m8[IEEE802154_LONG_ADDRESS_LEN - 1 - i];
     }
     _set_long_addr(reversed_addr);
 }
@@ -437,7 +437,7 @@ otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t a
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
     /* hskim: Necessary to support polling procedure */
     DEBUG("otPlatRadioAddSrcMatchExtEntry %u\n", ext_address_list+1);
@@ -463,7 +463,7 @@ otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
     /* hskim: Necessary to support polling procedure */
     DEBUG("otPlatRadioClearSrcMatchExtEntry %u\n", ext_address_list-1);

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -39,30 +39,7 @@
 
 #define RADIO_IEEE802154_FCS_LEN    (2U)
 #define IEEE802154_ACK_LENGTH (5)
-enum
-{
-    IEEE802154_FRAME_TYPE_MASK        = 0x7,     ///< (IEEE 802.15.4-2006) PSDU.FCF.frameType
-    IEEE802154_FRAME_TYPE_ACK         = 0x2,     ///< (IEEE 802.15.4-2006) frame type: ACK
-    IEEE802154_FRAME_PENDING          = (1<<4),  ///< (IEEE 802.15.4-2006) PSDU.FCF.bFramePending
-    IEEE802154_ACK_REQUEST            = (1<<5),  ///< (IEEE 802.15.4-2006) PSDU.FCF.bAR
-    IEEE802154_DSN_OFFSET             = 2,       ///< (IEEE 802.15.4-2006) PSDU.sequenceNumber
-    IEEE802154_MAC_MIN_BE             = 1,       ///< (IEEE 802.15.4-2006) macMinBE
-    IEEE802154_MAC_MAX_BE             = 5,       ///< (IEEE 802.15.4-2006) macMaxBE
-    IEEE802154_MAC_MAX_CSMA_BACKOFFS  = 4,       ///< (IEEE 802.15.4-2006) macMaxCSMABackoffs
-    IEEE802154_MAC_MAX_FRAMES_RETRIES = 3,       ///< (IEEE 802.15.4-2006) macMaxFrameRetries
-    IEEE802154_A_UINT_BACKOFF_PERIOD  = 20,      ///< (IEEE 802.15.4-2006 7.4.1) MAC constants
-    IEEE802154_A_TURNAROUND_TIME      = 12,      ///< (IEEE 802.15.4-2006 6.4.1) PHY constants
-    IEEE802154_PHY_SHR_DURATION       = 10,
-    ///< (IEEE 802.15.4-2006 6.4.2) PHY PIB attribute, specifically the O-QPSK PHY
-    IEEE802154_PHY_SYMBOLS_PER_OCTET  = 2,
-    ///< (IEEE 802.15.4-2006 6.4.2) PHY PIB attribute, specifically the O-QPSK PHY
-    IEEE802154_MAC_ACK_WAIT_DURATION  = (IEEE802154_A_UINT_BACKOFF_PERIOD +
-                                         IEEE802154_A_TURNAROUND_TIME     +
-                                         IEEE802154_PHY_SHR_DURATION      +
-                                         ( 6 * IEEE802154_PHY_SYMBOLS_PER_OCTET)),
-    ///< (IEEE 802.15.4-2006 7.4.2) macAckWaitDuration PIB attribute
-    IEEE802154_SYMBOLS_PER_SEC        = 62500    ///< (IEEE 802.15.4-2006 6.5.3.2) O-QPSK symbol rate
-};
+#define IEEE802154_DSN_OFFSET (2)
 
 static otRadioFrame sTransmitFrame;
 static otRadioFrame sReceiveFrame;
@@ -214,11 +191,11 @@ static inline otRadioFrame _create_fake_ack_frame(bool ackPending)
 
     ackFrame.mPsdu = psdu;
     ackFrame.mLength = IEEE802154_ACK_LENGTH;
-    ackFrame.mPsdu[0] = IEEE802154_FRAME_TYPE_ACK;
+    ackFrame.mPsdu[0] = IEEE802154_FCF_TYPE_ACK;
 
     if (ackPending)
     {
-        ackFrame.mPsdu[0] |= IEEE802154_FRAME_PENDING;
+        ackFrame.mPsdu[0] |= IEEE802154_FCF_FRAME_PEND;
     }
 
     ackFrame.mPsdu[1] = 0;


### PR DESCRIPTION
- replace the obsolete otInstanceInit() method with the new otInstanceInitSingle() method
- update to the newer alarm interface
- replace obsolete otPlatRadioTransmitDone with otPlatRadioTxDone 
- update extended address to its new struct definition
- add a SERIAL_NUMBER flag, so "make flash" can choose which serial port to program to