### PR TITLE
Add support for DMA in ADC driver

### DIFF
--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -234,6 +234,19 @@ static const spi_conf_t spi_config[] = {
 
 
 /**
+ * @name DMAC configuration
+ * @{
+ */
+#define DMAC_NUMOF         (1U)
+
+#define DMAC_DEV          DMAC
+#define DMAC_IRQ          DMAC_IRQn
+#define DMAC_ISR          isr_dmac
+/* Number of enabled channels: up to 12 */
+#define DMAC_EN_CHANNELS    1
+/** @} */
+
+/**
  * @name Sensor configuration
  * @{
  */
@@ -248,7 +261,7 @@ static const spi_conf_t spi_config[] = {
 #define TMP006_PARAMS_BOARD     { .i2c  = I2C_0, \
                                   .addr = 0x44, \
                                   .rate  = TMP006_CONFIG_CR_AS2 }
-#define TMP006_CONVERSION_TIME  550000UL  
+#define TMP006_CONVERSION_TIME  550000UL
 
 #define APDS9007_PARAMS_BOARD    { .gpio = GPIO_PIN(PA,28), \
 								   .adc  = ADC_PIN_PA08, \

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -15,6 +15,7 @@
  *
  * @author      Michael Andersen <m.andersen@berkeley.edu>
  * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ * @author      Sam Kumar <samkumar@berkeley.edu>
  * @author      Rane Balslev (SAMR21) <ranebalslev@gmail.com>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Mark Solters <msolters@driblet.io>
@@ -25,7 +26,9 @@
 #include <stdint.h>
 #include "cpu.h"
 
+#include "mutex.h"
 #include "periph/adc.h"
+#include "periph/dmac.h"
 #include "periph_conf.h"
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -113,10 +116,7 @@ int adc_init(adc_t channel) {
     return 0;
 }
 
-
-int adc_sample(adc_t channel, adc_res_t res){
-    int output;
-
+int adc_sample_start(adc_t channel, adc_res_t res) {
     /* Set input channel for ADC */
     int chan = ADC_GET_CHANNEL(channel);
     ADC_DEV->INPUTCTRL.bit.MUXPOS = chan;
@@ -153,22 +153,125 @@ int adc_sample(adc_t channel, adc_res_t res){
     /* Start the conversion. */
     ADC_DEV->SWTRIG.reg = ADC_SWTRIG_START;
 
+    return 0;
+}
+
+void adc_sample_wait(void) {
     /* Wait for the result. */
     while (!(ADC_DEV->INTFLAG.reg & ADC_INTFLAG_RESRDY));
+}
 
+int adc_sample_read(void) {
     /* Read result */
-    output = (int)ADC_DEV->RESULT.reg;
+    int output = (int) ADC_DEV->RESULT.reg;
     while(ADC_DEV->STATUS.reg & ADC_STATUS_SYNCBUSY);
+    return output;
+}
 
+void adc_sample_end(void) {
     ADC_DEV->CTRLA.bit.ENABLE = 0;
     while(ADC_DEV->STATUS.reg & ADC_STATUS_SYNCBUSY);
 
     /*  Disable bandgap */
     SYSCTRL->VREF.reg &= ~SYSCTRL_VREF_BGOUTEN;
+}
 
-    /* Return result. */
+
+int adc_sample_without_dma(adc_t channel, adc_res_t res) {
+    int error = adc_sample_start(channel, res);
+    if (error != 0) {
+        return error;
+    }
+    adc_sample_wait();
+    int output = adc_sample_read();
+    adc_sample_end();
     return output;
 }
 
+struct adc_dma_waiter {
+    mutex_t waiter;
+    volatile int error;
+};
+
+void adc_dma_unblock(void* arg, int error) {
+    struct adc_dma_waiter* waiter = arg;
+    waiter->error = error;
+    mutex_unlock(&waiter->waiter);
+}
+
+void adc_configure_dma_channel(dma_channel_t channel) {
+    dma_channel_set_current(channel);
+    dma_channel_reset_current();
+
+    dma_channel_periph_config_t periph_config;
+    periph_config.on_trigger = DMAC_ACTION_TRANSACTION;
+    periph_config.periph_src = 0x27; // this is the ADC
+    dma_channel_configure_periph_current(&periph_config);
+}
+
+int adc_sample_with_dma(adc_t adc_channel, adc_res_t res, dma_channel_t dma_channel) {
+    volatile uint16_t result;
+
+    dma_channel_memory_config_t memory_config;
+    memory_config.source = (volatile void*) &ADC_DEV->RESULT.reg;
+    memory_config.destination = &result;
+    memory_config.beatsize = DMAC_BEATSIZE_HALFWORD;
+    memory_config.num_beats = 1;
+    dma_channel_configure_memory(dma_channel, &memory_config);
+
+    struct adc_dma_waiter waiter;
+    mutex_init(&waiter.waiter);
+    waiter.error = 0;
+    dma_channel_register_callback(dma_channel, adc_dma_unblock, &waiter);
+
+    dma_channel_set_current(dma_channel);
+    dma_channel_enable_current();
+
+    /* Turn on RUN_IN_STANDBY so CPU can sleep while ADC does work. */
+    ADC_DEV->CTRLA.bit.RUNSTDBY = 1;
+
+    int start_error = adc_sample_start(adc_channel, res);
+    if (start_error != 0) {
+        ADC_DEV->CTRLA.bit.RUNSTDBY = 0;
+        dma_channel_disable_current();
+        return start_error;
+    }
+
+    mutex_lock(&waiter.waiter);
+    mutex_lock(&waiter.waiter);
+
+    // Thread blocks here until result is ready
+
+    /* Turn off RUN_IN_STANDBY to save power */
+    ADC_DEV->CTRLA.bit.RUNSTDBY = 0;
+
+    mutex_unlock(&waiter.waiter);
+    dma_channel_disable_current();
+    adc_sample_end();
+
+    if (waiter.error != 0) {
+        return waiter.error;
+    }
+
+    return (int) result;
+}
+
+dma_channel_t default_dma_channel = DMA_CHANNEL_UNDEF;
+
+int adc_sample(adc_t channel, adc_res_t res) {
+    if (default_dma_channel == DMA_CHANNEL_UNDEF) {
+        return adc_sample_without_dma(channel, res);
+    }
+
+    return adc_sample_with_dma(channel, res, default_dma_channel);
+}
+
+void adc_set_dma_channel(dma_channel_t channel) {
+    if (channel != DMA_CHANNEL_UNDEF) {
+        adc_configure_dma_channel(channel);
+    }
+
+    default_dma_channel = channel;
+}
 
 #endif /* ADC_NUMOF */

--- a/cpu/sam0_common/periph/dmac.c
+++ b/cpu/sam0_common/periph/dmac.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2017 Sam Kumar
+ * Copyright (C) 2017 University of California, Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <stdint.h>
+#include "cpu.h"
+
+#include "periph/dmac.h"
+#include "periph_conf.h"
+#include "pm_layered.h"
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* Guard in case no DMAC is defined */
+#if DMAC_NUMOF
+
+/* Transfer descriptor sections. */
+volatile DmacDescriptor descriptor_section[DMAC_EN_CHANNELS] __attribute__((aligned(16)));
+volatile DmacDescriptor writeback_section[DMAC_EN_CHANNELS] __attribute__((aligned(16)));
+
+/* DMA channel callbacks. */
+typedef struct {
+    dma_callback_t callback;
+    void* arg;
+} dma_callback_entry_t;
+
+dma_callback_entry_t channel_callbacks[DMAC_EN_CHANNELS];
+
+/* DMA Controller Configuration */
+
+void dmac_init(void) {
+    dmac_disable();
+    dmac_reset();
+    dmac_configure();
+    dmac_enable();
+}
+
+void dmac_enable(void) {
+    /* Turn on power manager for DMAC */
+    PM->APBBMASK.reg |= PM_APBBMASK_DMAC;
+    PM->AHBMASK.reg |= PM_AHBMASK_DMAC;
+
+    NVIC_EnableIRQ(DMAC_IRQ);
+    DMAC_DEV->CTRL.reg = 0x0F02;
+}
+
+void dmac_disable(void) {
+    DMAC_DEV->CTRL.reg = 0x0000;
+    NVIC_DisableIRQ(DMAC_IRQ);
+
+    /* Turn off power management for DMA. */
+    //PM->APBBMASK.reg &= ~PM_APBBMASK_DMAC;
+    //PM->AHBMASK.reg &= ~PM_AHBMASK_DMAC;
+}
+
+void dmac_reset(void) {
+    DMAC_DEV->CTRL.reg = 0x0001;
+}
+
+void dmac_configure(void) {
+    DMAC_DEV->BASEADDR.reg = (uint32_t) &descriptor_section[0];
+    DMAC_DEV->WRBADDR.reg = (uint32_t) &writeback_section[0];
+    DMAC_DEV->DBGCTRL.reg = 0x01;
+}
+
+/* DMA Channel Configuration */
+
+void dma_channel_register_callback(dma_channel_t channel, dma_callback_t callback, void* arg) {
+    dma_callback_entry_t* entry = &channel_callbacks[channel];
+    entry->callback = callback;
+    entry->arg = arg;
+}
+
+void dma_channel_set_current(dma_channel_t channel) {
+    DMAC_DEV->CHID.reg = channel & 0x0F;
+}
+
+void dma_channel_enable_current(void) {
+    pm_block(0);
+    DMAC_DEV->CHINTENSET.reg = 0x07;
+    DMAC_DEV->CHCTRLA.reg = 0x02;
+}
+
+void dma_channel_disable_current(void) {
+    DMAC_DEV->CHCTRLA.reg = 0x00;
+    DMAC_DEV->CHINTENCLR.reg = 0x07;
+    pm_unblock(0);
+}
+
+void dma_channel_reset_current(void) {
+    DMAC_DEV->CHCTRLA.reg = 0x01;
+}
+
+void dma_channel_configure_periph_current(dma_channel_periph_config_t* config) {
+    uint32_t chctrlb_reg = (((uint32_t) (config->periph_src & 0x3F)) << 8);
+    switch (config->on_trigger) {
+    case DMAC_ACTION_BEAT:
+        chctrlb_reg |= 0x00800000;
+        break;
+    case DMAC_ACTION_BLOCK:
+        chctrlb_reg |= 0x00000000;
+        break;
+    case DMAC_ACTION_TRANSACTION:
+        chctrlb_reg |= 0x00C00000;
+        break;
+    }
+    DMAC_DEV->CHCTRLB.reg = chctrlb_reg;
+}
+
+void dma_channel_configure_memory(dma_channel_t channel, dma_channel_memory_config_t* config) {
+    volatile DmacDescriptor* desc = &descriptor_section[channel];
+    uint16_t btctrl_reg = 0x0009; // interrupt at end of block, and valid bit
+    switch (config->beatsize) {
+    case DMAC_BEATSIZE_BYTE:
+        btctrl_reg |= 0x0000;
+        break;
+    case DMAC_BEATSIZE_HALFWORD:
+        btctrl_reg |= 0x0100;
+        break;
+    case DMAC_BEATSIZE_WORD:
+        btctrl_reg |= 0x0200;
+        break;
+    }
+    desc->BTCTRL.reg = btctrl_reg;
+    desc->BTCNT.reg = config->num_beats;
+    desc->SRCADDR.reg = (uint32_t) config->source;
+    desc->DSTADDR.reg = (uint32_t) config->destination;
+    desc->DESCADDR.reg = 0x00000000; // Don't handle linked descriptors
+}
+
+void DMAC_ISR(void) {
+    uint32_t intstatus = DMAC_DEV->INTSTATUS.reg;
+
+    dma_channel_t channel = 0;
+    while (intstatus != 0) {
+        uint32_t pending = intstatus & 0x00000001;
+        if (pending != 0) {
+            assert(channel < DMAC_EN_CHANNELS);
+
+            int error;
+
+            // Get the reason (finished, or error)
+            uint8_t reason = DMAC_DEV->CHINTFLAG.reg;
+            if ((reason & 0x01) == 0x01)  {
+                error = 1;
+            } else {
+                error = 0;
+                assert((reason & 0x02) == 0x02);
+            }
+
+            // Clear the interrupt
+            DMAC_DEV->CHINTFLAG.reg = 0x07;
+
+            dma_callback_entry_t* entry = &channel_callbacks[channel];
+            entry->callback(entry->arg, error);
+        }
+
+        intstatus >>= 1;
+        channel++;
+    }
+
+    cortexm_isr_end();
+}
+
+#endif /* DMAC_NUMOF */

--- a/drivers/apds9007/apds9007.c
+++ b/drivers/apds9007/apds9007.c
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #include "apds9007.h"
+#include "mutex.h"
 #include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)
@@ -31,7 +32,7 @@
 int apds9007_set_active(apds9007_t *dev) {
     gpio_write(dev->p.gpio, 0);
     return 0;
-} 
+}
 
 int apds9007_set_idle(apds9007_t *dev) {
     gpio_write(dev->p.gpio, 1);
@@ -55,4 +56,3 @@ int apds9007_read(apds9007_t *dev, int16_t *light) {
     apds9007_set_idle(dev);
     return 0;
 }
-

--- a/drivers/apds9007/apds9007_saul.c
+++ b/drivers/apds9007/apds9007_saul.c
@@ -25,6 +25,7 @@
 
 static int read(const void *dev, phydat_t *res) {
     apds9007_t *d = (apds9007_t *)dev;
+
     if (apds9007_read(d, &(res->val[0]))) {
         /* Read failure */
         return -ECANCELED;

--- a/drivers/include/apds9007.h
+++ b/drivers/include/apds9007.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include "periph/gpio.h"
 #include "periph/adc.h"
+#include "periph/dmac.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,6 +77,7 @@ int apds9007_set_active(apds9007_t* dev);
 int apds9007_set_idle(apds9007_t* dev);
 
 int apds9007_read(apds9007_t* dev, int16_t *light);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -47,6 +47,7 @@
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
+#include "periph/dmac.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,6 +123,17 @@ int adc_init(adc_t line);
  * @return                  -1 if resolution is not applicable
  */
 int adc_sample(adc_t line, adc_res_t res);
+
+/**
+ * @brief   Set the DMA channel to use for ADC sampling.
+ *
+ * This function sets the DMA channel to use for ADC sampling. If the provided
+ * channel is DMA_CHANNEL_UNDEF, then the ADC driver will use spin loops to wait
+ * for the result, instead of putting the thread to sleep while waiting.
+ *
+ * @param[in] channel       the DMA channel to use, or DMA_CHANNEL_UNDEF
+ */
+void adc_set_dma_channel(dma_channel_t channel);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/dmac.h
+++ b/drivers/include/periph/dmac.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2017 Sam Kumar
+ * Copyright (C) 2017 University of California, Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef PERIPH_DMAC_H
+#define PERIPH_DMAC_H
+
+#include <limits.h>
+
+#include "periph_cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Define default DMAC channel type identifier
+ * @{
+ */
+#ifndef HAVE_DMAC_T
+typedef unsigned int dma_channel_t;
+#endif
+/** @} */
+
+/**
+ * @brief   Default DMA channel; undefined value
+ * @{
+ */
+#ifndef DMA_CHANNEL_UNDEF
+#define DMA_CHANNEL_UNDEF   (UINT_MAX)
+#endif
+/** @} */
+
+/**
+ * @brief   Default DMAC channel access macro (zero-indexed)
+ * @{
+ */
+#ifndef DMA_CHANNEL
+#define DMA_CHANNEL(x)     (x)
+#endif
+/** @} */
+
+typedef void (*dma_callback_t)(void*, int);
+
+typedef enum {
+    DMAC_BEATSIZE_BYTE = 0,
+    DMAC_BEATSIZE_HALFWORD,
+    DMAC_BEATSIZE_WORD,
+} dmac_beatsize_t;
+
+typedef enum {
+    DMAC_ACTION_BLOCK = 0,
+    DMAC_ACTION_BEAT,
+    DMAC_ACTION_TRANSACTION
+} dmac_action_t;
+
+typedef struct {
+    volatile void* source;
+    volatile void* destination;
+    dmac_beatsize_t beatsize;
+    uint16_t num_beats;
+} dma_channel_memory_config_t;
+
+typedef struct {
+    dmac_action_t on_trigger;
+    uint8_t periph_src;
+} dma_channel_periph_config_t;
+
+void dmac_init(void);
+
+void dmac_enable(void);
+void dmac_disable(void);
+void dmac_reset(void);
+void dmac_configure(void);
+
+void dma_channel_register_callback(dma_channel_t channel, dma_callback_t callback, void* arg);
+void dma_channel_set_current(dma_channel_t channel);
+void dma_channel_enable_current(void);
+void dma_channel_disable_current(void);
+void dma_channel_reset_current(void);
+void dma_channel_configure_periph_current(dma_channel_periph_config_t* config);
+void dma_channel_configure_memory(dma_channel_t channel, dma_channel_memory_config_t* config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_ADC_H */
+/** @} */


### PR DESCRIPTION
This adds support for DMA in the ADC driver.

Applications need to include two lines at the top of the main() function:
`
dmac_init();
adc_set_dma_channel(0);
`

Then, all calls to adc_sample() will be done using DMA. This means that the threads will sleep, instead of busy waiting, while the ADC performs the reading.