### PR TITLE
Add support for DMA in ADC, I2C, and SPI drivers

### DIFF
--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -223,6 +223,7 @@ static const spi_conf_t spi_config[] = {
 #define I2C_0_DEV           SERCOM3->I2CM
 #define I2C_0_IRQ           SERCOM3_IRQn
 #define I2C_0_ISR           isr_sercom3
+#define I2C_0_SERCOM_NUM    3
 /* I2C 0 GCLK */
 #define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
 #define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
@@ -232,6 +233,19 @@ static const spi_conf_t spi_config[] = {
 #define I2C_0_MUX           GPIO_MUX_D
 /** @} */
 
+
+/**
+ * @name DMAC configuration
+ * @{
+ */
+#define DMAC_NUMOF         (1U)
+
+#define DMAC_DEV          DMAC
+#define DMAC_IRQ          DMAC_IRQn
+#define DMAC_ISR          isr_dmac
+/* Number of enabled channels */
+#define DMAC_EN_CHANNELS    12
+/** @} */
 
 /**
  * @name Sensor configuration
@@ -248,7 +262,7 @@ static const spi_conf_t spi_config[] = {
 #define TMP006_PARAMS_BOARD     { .i2c  = I2C_0, \
                                   .addr = 0x44, \
                                   .rate  = TMP006_CONFIG_CR_AS2 }
-#define TMP006_CONVERSION_TIME  550000UL  
+#define TMP006_CONVERSION_TIME  550000UL
 
 #define APDS9007_PARAMS_BOARD    { .gpio = GPIO_PIN(PA,28), \
 								   .adc  = ADC_PIN_PA08, \

--- a/cpu/sam0_common/periph/dmac.c
+++ b/cpu/sam0_common/periph/dmac.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2017 Sam Kumar
+ * Copyright (C) 2017 University of California, Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <stdint.h>
+#include "cpu.h"
+
+#include "periph/dmac.h"
+#include "periph_conf.h"
+#include "pm_layered.h"
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* Guard in case no DMAC is defined */
+#if DMAC_NUMOF
+
+/* Transfer descriptor sections. */
+volatile DmacDescriptor descriptor_section[DMAC_EN_CHANNELS] __attribute__((aligned(16)));
+volatile DmacDescriptor writeback_section[DMAC_EN_CHANNELS] __attribute__((aligned(16)));
+
+/* DMA channel callbacks. */
+typedef struct {
+    dma_callback_t callback;
+    void* arg;
+} dma_callback_entry_t;
+
+dma_callback_entry_t channel_callbacks[DMAC_EN_CHANNELS];
+
+/* DMA Controller Configuration */
+
+void dmac_init(void) {
+    dmac_disable();
+    dmac_reset();
+    dmac_configure();
+    dmac_enable();
+}
+
+void dmac_enable(void) {
+    /* Turn on power manager for DMAC */
+    PM->APBBMASK.reg |= PM_APBBMASK_DMAC;
+    PM->AHBMASK.reg |= PM_AHBMASK_DMAC;
+
+    NVIC_EnableIRQ(DMAC_IRQ);
+    DMAC_DEV->CTRL.reg = 0x0F02;
+}
+
+void dmac_disable(void) {
+    DMAC_DEV->CTRL.reg = 0x0000;
+    NVIC_DisableIRQ(DMAC_IRQ);
+
+    /* Turn off power management for DMA. */
+    //PM->APBBMASK.reg &= ~PM_APBBMASK_DMAC;
+    //PM->AHBMASK.reg &= ~PM_AHBMASK_DMAC;
+}
+
+void dmac_reset(void) {
+    DMAC_DEV->CTRL.reg = 0x0001;
+}
+
+void dmac_configure(void) {
+    DMAC_DEV->BASEADDR.reg = (uint32_t) &descriptor_section[0];
+    DMAC_DEV->WRBADDR.reg = (uint32_t) &writeback_section[0];
+    DMAC_DEV->DBGCTRL.reg = 0x01;
+}
+
+/* DMA Channel Configuration */
+
+void dma_channel_register_callback(dma_channel_t channel, dma_callback_t callback, void* arg) {
+    dma_callback_entry_t* entry = &channel_callbacks[channel];
+    entry->callback = callback;
+    entry->arg = arg;
+}
+
+void dma_channel_set_current(dma_channel_t channel) {
+    DMAC_DEV->CHID.reg = channel & 0x0F;
+}
+
+void dma_channel_enable_current(void) {
+    pm_block(0);
+    DMAC_DEV->CHINTENSET.reg = 0x07;
+    DMAC_DEV->CHCTRLA.reg = 0x02;
+}
+
+void dma_channel_disable_current(void) {
+    DMAC_DEV->CHCTRLA.reg = 0x00;
+    DMAC_DEV->CHINTENCLR.reg = 0x07;
+    pm_unblock(0);
+}
+
+void dma_channel_reset_current(void) {
+    DMAC_DEV->CHCTRLA.reg = 0x01;
+}
+
+void dma_channel_configure_periph_current(dma_channel_periph_config_t* config) {
+    uint32_t chctrlb_reg = (((uint32_t) (config->periph_src & 0x3F)) << 8);
+    switch (config->on_trigger) {
+    case DMAC_ACTION_BEAT:
+        chctrlb_reg |= 0x00800000;
+        break;
+    case DMAC_ACTION_BLOCK:
+        chctrlb_reg |= 0x00000000;
+        break;
+    case DMAC_ACTION_TRANSACTION:
+        chctrlb_reg |= 0x00C00000;
+        break;
+    }
+    DMAC_DEV->CHCTRLB.reg = chctrlb_reg;
+}
+
+
+void dma_channel_create_descriptor(volatile void* blob, dma_channel_memory_config_t* config) {
+    volatile DmacDescriptor* desc = blob;
+    uint16_t btctrl_reg = 0x0001; // Valid bit set
+    switch (config->beatsize) {
+    case DMAC_BEATSIZE_BYTE:
+        btctrl_reg |= 0x0000;
+        break;
+    case DMAC_BEATSIZE_HALFWORD:
+        btctrl_reg |= 0x0100;
+        break;
+    case DMAC_BEATSIZE_WORD:
+        btctrl_reg |= 0x0200;
+        break;
+    }
+    btctrl_reg |= ((uint16_t) config->stepsize) << 13;
+    btctrl_reg |= ((uint16_t) config->stepsel) << 12;
+    if (config->increment_destination) {
+        btctrl_reg |= 0x0800;
+    }
+    if (config->increment_source) {
+        btctrl_reg |= 0x0400;
+    }
+    if (config->next_block == NULL) {
+        btctrl_reg |= 0x0008; // Configure the last block to give an interrupt
+    }
+    desc->BTCTRL.reg = btctrl_reg;
+    desc->BTCNT.reg = config->num_beats;
+    desc->SRCADDR.reg = (uint32_t) config->source;
+    desc->DSTADDR.reg = (uint32_t) config->destination;
+    if (config->next_block == NULL) {
+        desc->DESCADDR.reg = 0x00000000;
+    } else {
+        desc->DESCADDR.reg = (uint32_t) &config->next_block->descriptor_blob[0];
+    }
+}
+
+void dma_channel_configure_memory(dma_channel_t channel, dma_channel_memory_config_t* config) {
+    volatile DmacDescriptor* desc = dma_channel_get_descriptor_address(channel);
+    for (;;) {
+        dma_channel_create_descriptor(desc, config);
+        if (config->next_block == NULL) {
+            break;
+        }
+        desc = (volatile DmacDescriptor*) &config->next_block->descriptor_blob[0];
+        config = &config->next_block->config;
+    }
+}
+
+volatile void* dma_channel_get_descriptor_address(dma_channel_t channel) {
+    return &descriptor_section[channel];
+}
+
+void DMAC_ISR(void) {
+    uint32_t intstatus = DMAC_DEV->INTSTATUS.reg;
+
+    dma_channel_t channel = 0;
+    while (intstatus != 0) {
+        uint32_t pending = intstatus & 0x00000001;
+        if (pending != 0) {
+            assert(channel < DMAC_EN_CHANNELS);
+
+            dma_channel_set_current(channel);
+
+            int error;
+
+            // Get the reason (finished, or error)
+            uint8_t reason = DMAC_DEV->CHINTFLAG.reg;
+            if ((reason & 0x01) == 0x01)  {
+                error = 1;
+            } else {
+                error = 0;
+                assert((reason & 0x02) == 0x02);
+            }
+
+            // Clear the interrupt
+            DMAC_DEV->CHINTFLAG.reg = 0x07;
+
+            dma_callback_entry_t* entry = &channel_callbacks[channel];
+            entry->callback(entry->arg, error);
+        }
+
+        intstatus >>= 1;
+        channel++;
+    }
+
+    cortexm_isr_end();
+}
+
+#endif /* DMAC_NUMOF */

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -26,6 +26,7 @@
 #include "board.h"
 #include "mutex.h"
 #include "periph_conf.h"
+#include "periph/dmac.h"
 #include "periph/i2c.h"
 
 #include "sched.h"
@@ -58,21 +59,33 @@ static inline int _read(SercomI2cm *dev, uint8_t *data, int length);
 static inline void _stop(SercomI2cm *dev);
 static inline int _wait_for_response(SercomI2cm *dev, uint32_t max_timeout_counter);
 
+static int _start_dma(SercomI2cm *dev, uint8_t address, uint8_t rw_flag, uint8_t total_bytes, dma_channel_t dma_channel);
+static int _transact_dma(SercomI2cm* dev, dma_channel_t dma_channel);
+static void _configure_write_dma(SercomI2cm *dev, const uint8_t *data, int length, dma_channel_t dma_channel);
+static void _configure_read_dma(SercomI2cm *dev, uint8_t *data, int length, dma_channel_t dma_channel);
+static void _stop_dma(SercomI2cm* dev);
+
+typedef struct {
+    mutex_t lock;
+    dma_channel_t dma_channel;
+} i2c_state_t;
+
 /**
- * @brief Array holding one pre-initialized mutex for each I2C device
+ * @brief Array holding one pre-initialized mutex for each I2C device, and the
+ *        default DMA channel to use
  */
-static mutex_t locks[] = {
+static i2c_state_t i2c_state[] = {
 #if I2C_0_EN
-    [I2C_0] = MUTEX_INIT,
+    [I2C_0] = { MUTEX_INIT, DMA_CHANNEL_UNDEF },
 #endif
 #if I2C_1_EN
-    [I2C_1] = MUTEX_INIT,
+    [I2C_1] = { MUTEX_INIT, DMA_CHANNEL_UNDEF },
 #endif
 #if I2C_2_EN
-    [I2C_2] = MUTEX_INIT
+    [I2C_2] = { MUTEX_INIT, DMA_CHANNEL_UNDEF },
 #endif
 #if I2C_3_EN
-    [I2C_3] = MUTEX_INIT
+    [I2C_3] = { MUTEX_INIT, DMA_CHANNEL_UNDEF }
 #endif
 };
 
@@ -215,7 +228,7 @@ int i2c_acquire(i2c_t dev)
     if (dev >= I2C_NUMOF) {
         return -1;
     }
-    mutex_lock(&locks[dev]);
+    mutex_lock(&i2c_state[dev].lock);
     return 0;
 }
 
@@ -224,7 +237,7 @@ int i2c_release(i2c_t dev)
     if (dev >= I2C_NUMOF) {
         return -1;
     }
-    mutex_unlock(&locks[dev]);
+    mutex_unlock(&i2c_state[dev].lock);
     return 0;
 }
 
@@ -245,6 +258,15 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 #endif
         default:
             return -1;
+    }
+
+    dma_channel_t i2c_dma_channel = i2c_state[dev].dma_channel;
+    if (i2c_dma_channel != DMA_CHANNEL_UNDEF && !irq_is_in()) {
+        _configure_read_dma(i2c, data, length, i2c_dma_channel);
+        _start_dma(i2c, address, I2C_FLAG_READ, (uint8_t) length, i2c_dma_channel);
+        _transact_dma(i2c, i2c_dma_channel);
+        _stop_dma(i2c);
+        return length;
     }
 
     /* start transmission and send slave address */
@@ -279,6 +301,15 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
             return -1;
     }
 
+    dma_channel_t i2c_dma_channel = i2c_state[dev].dma_channel;
+    if (i2c_dma_channel != DMA_CHANNEL_UNDEF && !irq_is_in()) {
+        _configure_write_dma(i2c, &reg, 1, i2c_dma_channel);
+        _start_dma(i2c, address, I2C_FLAG_WRITE, 1, i2c_dma_channel);
+        _transact_dma(i2c, i2c_dma_channel);
+        _stop_dma(i2c);
+        return i2c_read_bytes(dev, address, data, length);
+    }
+
     /* start transmission and send slave address */
     if (_start(i2c, address, I2C_FLAG_WRITE) < 0) {
         return 0;
@@ -310,6 +341,15 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
             return -1;
     }
 
+    dma_channel_t i2c_dma_channel = i2c_state[dev].dma_channel;
+    if (i2c_dma_channel != DMA_CHANNEL_UNDEF && !irq_is_in()) {
+        _configure_write_dma(I2CSercom, data, length, i2c_dma_channel);
+        _start_dma(I2CSercom, address, I2C_FLAG_WRITE, length, i2c_dma_channel);
+        _transact_dma(I2CSercom, i2c_dma_channel);
+        _stop_dma(I2CSercom);
+        return length;
+    }
+
     if (_start(I2CSercom, address, I2C_FLAG_WRITE) < 0) {
         return 0;
     }
@@ -338,6 +378,57 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
 #endif
         default:
             return -1;
+    }
+
+    dma_channel_t i2c_dma_channel = i2c_state[dev].dma_channel;
+    if (i2c_dma_channel != DMA_CHANNEL_UNDEF && !irq_is_in()) {
+
+        /*
+         * We could just use the following six lines to do the work:
+         *
+         * _start_dma(i2c, address, I2C_FLAG_WRITE, 1 + (uint8_t) length, i2c_dma_channel);
+         * _configure_write_dma(i2c, &reg, 1, i2c_dma_channel);
+         * _transact_dma(i2c, i2c_dma_channel);
+         * _configure_write_dma(i2c, data, length, i2c_dma_channel);
+         * _transact_dma(i2c, i2c_dma_channel);
+         * _stop_dma(i2c);
+         *
+         * However, that would be inefficient, because the CPU wakes up between
+         * the two writes. Instead, we use a linked descriptor so the DMA
+         * performs both writes without waking up the CPU.
+         */
+
+        _start_dma(i2c, address, I2C_FLAG_WRITE, 1 + (uint8_t) length, i2c_dma_channel);
+
+        dma_channel_memory_config_t first_block;
+        dma_channel_linked_block_t second_block;
+
+        first_block.source = &reg;
+        first_block.destination = &i2c->DATA.reg;
+        first_block.beatsize = DMAC_BEATSIZE_BYTE;
+        first_block.num_beats = 1;
+        first_block.stepsize = DMAC_STEPSIZE_X1;
+        first_block.stepsel = DMAC_STEPSEL_SRC;
+        first_block.increment_source = false;
+        first_block.increment_destination = false;
+        first_block.next_block = &second_block;
+
+        second_block.config.source = ((const uint8_t*) data) + length;
+        second_block.config.destination = &i2c->DATA.reg;
+        second_block.config.beatsize = DMAC_BEATSIZE_BYTE;
+        second_block.config.num_beats = length;
+        second_block.config.stepsize = DMAC_STEPSIZE_X1;
+        second_block.config.stepsel = DMAC_STEPSEL_SRC;
+        second_block.config.increment_source = true;
+        second_block.config.increment_destination = false;
+        second_block.config.next_block = NULL;
+
+        dma_channel_configure_memory(i2c_dma_channel, &first_block);
+
+        _transact_dma(i2c, i2c_dma_channel);
+        _stop_dma(i2c);
+
+        return length;
     }
 
     /* start transmission and send slave address */
@@ -534,6 +625,110 @@ static inline int _wait_for_response(SercomI2cm *dev, uint32_t max_timeout_count
         }
     }
     return 0;
+}
+
+/* DMA Functionality */
+
+void i2c_set_dma_channel(i2c_t dev, dma_channel_t channel)
+{
+    if (channel != DMA_CHANNEL_UNDEF) {
+        dma_channel_set_current(channel);
+        dma_channel_reset_current();
+    }
+    i2c_state[dev].dma_channel = channel;
+}
+
+struct i2c_dma_waiter {
+    mutex_t waiter;
+    volatile int error;
+};
+
+void i2c_dma_unblock(void* arg, int error)
+{
+    struct i2c_dma_waiter* waiter = arg;
+    waiter->error = error;
+    mutex_unlock(&waiter->waiter);
+}
+
+static int _start_dma(SercomI2cm *dev, uint8_t address, uint8_t rw_flag, uint8_t total_bytes, dma_channel_t dma_channel)
+{
+    /* Wait for hardware module to sync */
+    DEBUG("Wait for device to be ready\n");
+    while (dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+
+    /* Set action to ACK. */
+    dev->CTRLB.reg &= ~SERCOM_I2CM_CTRLB_ACKACT;
+
+    /* Configure DMA channel. */
+    dma_channel_set_current(dma_channel);
+    dma_channel_periph_config_t periph_config;
+    periph_config.on_trigger = DMAC_ACTION_BEAT;
+    periph_config.periph_src = (I2C_0_SERCOM_NUM << 1) + ((rw_flag == I2C_FLAG_READ) ? 1 : 2);
+    dma_channel_configure_periph_current(&periph_config);
+
+    /* Send Start | Address | Write/Read | Total Length for Automatic STOP at the end. */
+    DEBUG("Generate start condition by sending address\n");
+    dev->ADDR.reg = (address << 1) | rw_flag | (1 << SERCOM_I2CM_ADDR_LENEN_Pos) | (0 << SERCOM_I2CM_ADDR_HS_Pos) | (((uint32_t) total_bytes) << 16);
+
+    return 0;
+}
+
+static int _transact_dma(SercomI2cm* dev, dma_channel_t dma_channel)
+{
+    struct i2c_dma_waiter waiter;
+    mutex_init(&waiter.waiter);
+    waiter.error = 0;
+
+    dma_channel_register_callback(dma_channel, i2c_dma_unblock, &waiter);
+
+    dma_channel_set_current(dma_channel);
+    mutex_lock(&waiter.waiter);
+    dma_channel_enable_current();
+    mutex_lock(&waiter.waiter);
+
+    // The thread blocks here until the transfer is complete
+
+    dma_channel_set_current(dma_channel);
+    dma_channel_disable_current();
+    mutex_unlock(&waiter.waiter);
+
+    return waiter.error;
+}
+
+static void _configure_write_dma(SercomI2cm* dev, const uint8_t* data, int length, dma_channel_t dma_channel)
+{
+    dma_channel_memory_config_t memory_config;
+    memory_config.source = (volatile void*) &data[length];
+    memory_config.destination = (volatile void*) &dev->DATA.reg;
+    memory_config.beatsize = DMAC_BEATSIZE_BYTE;
+    memory_config.num_beats = length;
+    memory_config.stepsize = DMAC_STEPSIZE_X1;
+    memory_config.stepsel = DMAC_STEPSEL_SRC;
+    memory_config.increment_source = true;
+    memory_config.increment_destination = false;
+    memory_config.next_block = NULL;
+    dma_channel_configure_memory(dma_channel, &memory_config);
+}
+
+static void _configure_read_dma(SercomI2cm* dev, uint8_t* data, int length, dma_channel_t dma_channel)
+{
+    dma_channel_memory_config_t memory_config;
+    memory_config.source = (volatile void*) &dev->DATA.reg;
+    memory_config.destination = (volatile void*) &data[length];
+    memory_config.beatsize = DMAC_BEATSIZE_BYTE;
+    memory_config.num_beats = length;
+    memory_config.stepsize = DMAC_STEPSIZE_X1;
+    memory_config.stepsel = DMAC_STEPSEL_DST;
+    memory_config.increment_source = false;
+    memory_config.increment_destination = true;
+    memory_config.next_block = NULL;
+    dma_channel_configure_memory(dma_channel, &memory_config);
+}
+
+static inline void _stop_dma(SercomI2cm *dev)
+{
+    /* Wait for bus to be idle again */
+    while ((dev->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk) != BUSSTATE_IDLE) {}
 }
 
 #endif /* I2C_NUMOF */

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -16,6 +16,7 @@
  * @file
  * @brief       Low-level SPI driver implementation
  *
+ * @author      Sam Kumar <samkumar@berkeley.edu>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Troels Hoffmeyer <troels.d.hoffmeyer@gmail.com>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
@@ -28,15 +29,23 @@
 #include "cpu.h"
 #include "mutex.h"
 #include "assert.h"
+#include "periph/dmac.h"
 #include "periph/spi.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+typedef struct {
+    mutex_t lock;
+    dma_channel_t read_dma_channel;
+    dma_channel_t write_dma_channel;
+} spi_state_t;
+
 /**
- * @brief Array holding one pre-initialized mutex for each SPI device
+ * @brief Array holding one pre-initialized mutex for each SPI device, and the
+ *        default DMA channels for that device.
  */
-static mutex_t locks[SPI_NUMOF];
+static spi_state_t spi_state[SPI_NUMOF];
 
 /**
  * @brief   Shortcut for accessing the used SPI SERCOM device
@@ -69,8 +78,10 @@ void spi_init(spi_t bus)
     /* make sure given bus is good */
     assert(bus < SPI_NUMOF);
 
-    /* initialize the device lock */
-    mutex_init(&locks[bus]);
+    /* initialize the device state */
+    mutex_init(&spi_state[bus].lock);
+    spi_state[bus].read_dma_channel = DMA_CHANNEL_UNDEF;
+    spi_state[bus].write_dma_channel = DMA_CHANNEL_UNDEF;
 
     /* configure pins and their muxes */
     spi_init_pins(bus);
@@ -115,7 +126,7 @@ void spi_init_pins(spi_t bus)
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     /* get exclusive access to the device */
-    mutex_lock(&locks[bus]);
+    mutex_lock(&spi_state[bus].lock);
     /* power on the device */
     poweron(bus);
 
@@ -149,8 +160,13 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 void spi_release(spi_t bus)
 {
     /* release access to the device */
-    mutex_unlock(&locks[bus]);
+    mutex_unlock(&spi_state[bus].lock);
 }
+
+int spi_dma_transact(spi_t bus, const volatile void* out, volatile void* in, size_t len);
+
+dma_channel_t spi_read_dma_channel = DMA_CHANNEL_UNDEF;
+dma_channel_t spi_write_dma_channel = DMA_CHANNEL_UNDEF;
 
 void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
                         const void *out, void *in, size_t len)
@@ -164,18 +180,135 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         gpio_clear((gpio_t)cs);
     }
 
-    for (int i = 0; i < (int)len; i++) {
-        uint8_t tmp = (out_buf) ? out_buf[i] : 0;
-        while (!(dev(bus)->INTFLAG.reg & SERCOM_SPI_INTFLAG_DRE)) {}
-        dev(bus)->DATA.reg = tmp;
-        while (!(dev(bus)->INTFLAG.reg & SERCOM_SPI_INTFLAG_RXC)) {}
-        tmp = (uint8_t)dev(bus)->DATA.reg;
-        if (in_buf) {
-            in_buf[i] = tmp;
+    if (spi_read_dma_channel == DMA_CHANNEL_UNDEF || irq_is_in()) {
+        for (int i = 0; i < (int)len; i++) {
+            uint8_t tmp = (out_buf) ? out_buf[i] : 0;
+            while (!(dev(bus)->INTFLAG.reg & SERCOM_SPI_INTFLAG_DRE)) {}
+            dev(bus)->DATA.reg = tmp;
+            while (!(dev(bus)->INTFLAG.reg & SERCOM_SPI_INTFLAG_RXC)) {}
+            tmp = (uint8_t)dev(bus)->DATA.reg;
+            if (in_buf) {
+                in_buf[i] = tmp;
+            }
         }
+    } else {
+        spi_dma_transact(bus, out_buf, in_buf, len);
     }
 
     if ((!cont) && (cs != SPI_CS_UNDEF)) {
         gpio_set((gpio_t)cs);
     }
+}
+
+void spi_set_dma_channel(spi_t bus, dma_channel_t read_channel, dma_channel_t write_channel)
+{
+    if (read_channel != DMA_CHANNEL_UNDEF) {
+        assert(write_channel != DMA_CHANNEL_UNDEF);
+        assert(read_channel != write_channel);
+
+        dma_channel_set_current(read_channel);
+        dma_channel_reset_current();
+        dma_channel_periph_config_t periph_config;
+        periph_config.on_trigger = DMAC_ACTION_BEAT;
+        periph_config.periph_src = 0x09;
+        dma_channel_configure_periph_current(&periph_config);
+
+        dma_channel_set_current(write_channel);
+        dma_channel_reset_current();
+        periph_config.periph_src++;
+        dma_channel_configure_periph_current(&periph_config);
+    }
+
+    spi_state[bus].read_dma_channel = read_channel;
+    spi_state[bus].write_dma_channel = write_channel;
+}
+
+struct spi_dma_waiter {
+    mutex_t waiter;
+    volatile int error;
+    int count;
+};
+
+void spi_dma_unblock(void* arg, int error)
+{
+    struct spi_dma_waiter* waiter = arg;
+    if (waiter->error == 0) {
+        waiter->error = error;
+    }
+    waiter->count++;
+    if (waiter->count == 2) {
+        mutex_unlock(&waiter->waiter);
+    } else if (waiter->count > 2) {
+        for (;;) {}
+    }
+}
+
+int spi_dma_transact(spi_t bus, const volatile void* out, volatile void* in, size_t len)
+{
+    SercomSpi* spi = dev(bus);
+    dma_channel_t spi_read_dma_channel = spi_state[bus].read_dma_channel;
+    dma_channel_t spi_write_dma_channel = spi_state[bus].write_dma_channel;
+
+    const uint8_t dummy_out = 0;
+    uint8_t dummy_in = 0;
+
+    dma_channel_memory_config_t memory_config;
+    memory_config.beatsize = DMAC_BEATSIZE_BYTE;
+    memory_config.num_beats = len;
+    memory_config.stepsize = DMAC_STEPSIZE_X1;
+    memory_config.next_block = NULL;
+
+    /* Configure read DMA channel */
+    if (in == NULL) {
+        memory_config.destination = &dummy_in;
+        memory_config.increment_destination = false;
+    } else {
+        memory_config.destination = ((volatile uint8_t*) in) + len;
+        memory_config.increment_destination = true;
+    }
+    memory_config.source = &spi->DATA.reg;
+    memory_config.stepsel = DMAC_STEPSEL_DST;
+    memory_config.increment_source = false;
+    dma_channel_configure_memory(spi_read_dma_channel, &memory_config);
+
+    /* Configure write DMA channel */
+    if (out == NULL) {
+        memory_config.source = &dummy_out;
+        memory_config.increment_source = false;
+    } else {
+        memory_config.source = ((const volatile uint8_t*) out) + len;
+        memory_config.increment_source = true;
+    }
+    memory_config.destination = &spi->DATA.reg;
+    memory_config.stepsel = DMAC_STEPSEL_SRC;
+    memory_config.increment_destination = false;
+    dma_channel_configure_memory(spi_write_dma_channel, &memory_config);
+
+    /* Set up thread to properly block */
+    struct spi_dma_waiter waiter;
+    mutex_init(&waiter.waiter);
+    waiter.error = 0;
+    waiter.count = 0;
+
+    dma_channel_register_callback(spi_read_dma_channel, spi_dma_unblock, &waiter);
+    dma_channel_register_callback(spi_write_dma_channel, spi_dma_unblock, &waiter);
+
+    /* Start the transaction */
+    mutex_lock(&waiter.waiter);
+    dma_channel_set_current(spi_read_dma_channel);
+    dma_channel_enable_current();
+    dma_channel_set_current(spi_write_dma_channel);
+    dma_channel_enable_current();
+
+    mutex_lock(&waiter.waiter);
+
+    // Once both DMA transactions are complete, the thread will progress
+
+    dma_channel_set_current(spi_read_dma_channel);
+    dma_channel_disable_current();
+    dma_channel_set_current(spi_write_dma_channel);
+    dma_channel_disable_current();
+    mutex_unlock(&waiter.waiter);
+
+    return waiter.error;
 }

--- a/drivers/apds9007/apds9007.c
+++ b/drivers/apds9007/apds9007.c
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #include "apds9007.h"
+#include "mutex.h"
 #include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)
@@ -31,7 +32,7 @@
 int apds9007_set_active(apds9007_t *dev) {
     gpio_write(dev->p.gpio, 0);
     return 0;
-} 
+}
 
 int apds9007_set_idle(apds9007_t *dev) {
     gpio_write(dev->p.gpio, 1);
@@ -55,4 +56,3 @@ int apds9007_read(apds9007_t *dev, int16_t *light) {
     apds9007_set_idle(dev);
     return 0;
 }
-

--- a/drivers/apds9007/apds9007_saul.c
+++ b/drivers/apds9007/apds9007_saul.c
@@ -25,6 +25,7 @@
 
 static int read(const void *dev, phydat_t *res) {
     apds9007_t *d = (apds9007_t *)dev;
+
     if (apds9007_read(d, &(res->val[0]))) {
         /* Read failure */
         return -ECANCELED;

--- a/drivers/fxos8700/fxos8700.c
+++ b/drivers/fxos8700/fxos8700.c
@@ -64,7 +64,7 @@ static int fxos8700_reset(fxos8700_t* dev)
     return 0;
 }
 
-int fxos8700_init(fxos8700_t* dev, const fxos8700_params_t *params) 
+int fxos8700_init(fxos8700_t* dev, const fxos8700_params_t *params)
 {
     dev->p.i2c = params->i2c;
     int rv;

--- a/drivers/include/apds9007.h
+++ b/drivers/include/apds9007.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include "periph/gpio.h"
 #include "periph/adc.h"
+#include "periph/dmac.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,6 +77,7 @@ int apds9007_set_active(apds9007_t* dev);
 int apds9007_set_idle(apds9007_t* dev);
 
 int apds9007_read(apds9007_t* dev, int16_t *light);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -47,6 +47,7 @@
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
+#include "periph/dmac.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,6 +123,17 @@ int adc_init(adc_t line);
  * @return                  -1 if resolution is not applicable
  */
 int adc_sample(adc_t line, adc_res_t res);
+
+/**
+ * @brief   Set the DMA channel to use for ADC sampling.
+ *
+ * This function sets the DMA channel to use for ADC sampling. If the provided
+ * channel is DMA_CHANNEL_UNDEF, then the ADC driver will use spin loops to wait
+ * for the result, instead of putting the thread to sleep while waiting.
+ *
+ * @param[in] channel       the DMA channel to use, or DMA_CHANNEL_UNDEF
+ */
+void adc_set_dma_channel(dma_channel_t channel);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/dmac.h
+++ b/drivers/include/periph/dmac.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2017 Sam Kumar
+ * Copyright (C) 2017 University of California, Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef PERIPH_DMAC_H
+#define PERIPH_DMAC_H
+
+#include <limits.h>
+
+#include "periph_cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Define default DMAC channel type identifier
+ * @{
+ */
+#ifndef HAVE_DMAC_T
+typedef unsigned int dma_channel_t;
+#endif
+/** @} */
+
+/**
+ * @brief   Default DMA channel; undefined value
+ * @{
+ */
+#ifndef DMA_CHANNEL_UNDEF
+#define DMA_CHANNEL_UNDEF   (UINT_MAX)
+#endif
+/** @} */
+
+/**
+ * @brief   Default DMAC channel access macro (zero-indexed)
+ * @{
+ */
+#ifndef DMA_CHANNEL
+#define DMA_CHANNEL(x)     (x)
+#endif
+/** @} */
+
+typedef void (*dma_callback_t)(void*, int);
+
+typedef enum {
+    DMAC_BEATSIZE_BYTE = 0,
+    DMAC_BEATSIZE_HALFWORD,
+    DMAC_BEATSIZE_WORD,
+} dmac_beatsize_t;
+
+typedef enum {
+    DMAC_ACTION_BLOCK = 0,
+    DMAC_ACTION_BEAT,
+    DMAC_ACTION_TRANSACTION
+} dmac_action_t;
+
+typedef enum {
+    DMAC_STEPSIZE_X1 = 0x0,
+    DMAC_STEPSIZE_X2 = 0x1,
+    DMAC_STEPSIZE_X4 = 0x2,
+    DMAC_STEPSIZE_X8 = 0x3,
+    DMAC_STEPSIZE_X16 = 0x4,
+    DMAC_STEPSIZE_X32 = 0x5,
+    DMAC_STEPSIZE_X64 = 0x6,
+    DMAC_STEPSIZE_X128 = 0x7
+} dmac_stepsize_t;
+
+typedef enum {
+    DMAC_STEPSEL_SRC = 0x0,
+    DMAC_STEPSEL_DST = 0x1
+} dmac_stepsel_t;
+
+struct dma_channel_linked_block_;
+typedef struct dma_channel_linked_block_ dma_channel_linked_block_t;
+
+typedef struct {
+    const volatile void* source;
+    volatile void* destination;
+    dmac_beatsize_t beatsize;
+    uint16_t num_beats;
+
+    dmac_stepsize_t stepsize;
+    dmac_stepsel_t stepsel;
+    bool increment_source;
+    bool increment_destination;
+
+    dma_channel_linked_block_t* next_block;
+} dma_channel_memory_config_t;
+
+typedef struct dma_channel_linked_block_ {
+    volatile uint8_t descriptor_blob[16] __attribute__((aligned(16)));
+    dma_channel_memory_config_t config;
+} dma_channel_linked_block_t;
+
+typedef struct {
+    dmac_action_t on_trigger;
+    uint8_t periph_src;
+} dma_channel_periph_config_t;
+
+void dmac_init(void);
+
+void dmac_enable(void);
+void dmac_disable(void);
+void dmac_reset(void);
+void dmac_configure(void);
+
+void dma_channel_register_callback(dma_channel_t channel, dma_callback_t callback, void* arg);
+void dma_channel_set_current(dma_channel_t channel);
+void dma_channel_enable_current(void);
+void dma_channel_disable_current(void);
+void dma_channel_reset_current(void);
+void dma_channel_configure_periph_current(dma_channel_periph_config_t* config);
+void dma_channel_create_descriptor(volatile void* descriptor, dma_channel_memory_config_t* config);
+void dma_channel_configure_memory(dma_channel_t channel, dma_channel_memory_config_t* config);
+volatile void* dma_channel_get_descriptor_address(dma_channel_t channel);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_ADC_H */
+/** @} */

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -72,6 +72,7 @@
  *          updated periph interface
  */
 #include "periph/dev_enums.h"
+#include "periph/dmac.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -287,6 +288,22 @@ void i2c_poweron(i2c_t dev);
  * @param[in] dev           the I2C device to power off
  */
 void i2c_poweroff(i2c_t dev);
+
+/**
+ * @brief   Set the DMA channel to use for the specified I2C device.
+ *
+ * If this function is called with channel set to valid DMA channel, then DMA
+ * will be used for the specified SPI device. This means that the thread will
+ * be blocked (i.e., put to sleep) for the transfer, and will be resumed
+ * (i.e., woken up) when the trasfer is complete. If channel is set to
+ * DMA_CHANNEL_UNDEF, then DMA is not used for the specified I2C device;
+ * instead the thread spin-waits (i.e., is not put to sleep) for each byte read
+ * and written.
+ *
+ * @param[in] dev       I2C device to use
+ * @param[in] channel   DMA channel to use for the specified I2C device
+ */
+void i2c_set_dma_channel(i2c_t dev, dma_channel_t channel);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -60,6 +60,7 @@
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
+#include "periph/dmac.h"
 #include "periph/gpio.h"
 
 #ifdef __cplusplus
@@ -317,6 +318,25 @@ uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out);
  */
 void spi_transfer_regs(spi_t bus, spi_cs_t cs, uint8_t reg,
                        const void *out, void *in, size_t len);
+
+/**
+ * @brief   Set the DMA channels to use for the specified SPI bus.
+ *
+ * If this function is called with read_channel and write_channel set to valid
+ * DMA channels, DMA will be used for SPI on the specified bus. This means that
+ * the thread will be blocked (i.e., put to sleep) for the transfer, and will
+ * be resumed (i.e., woken up) when the transfer is complete. The same channel
+ * may not be used for both read_channel and write_channel. If read_channel and
+ * write_channel are both set to DMA_CHANNEL_UNDEF, then DMA is not used for
+ * the specified SPI bus; instead, the thread spin-waits (i.e., is not put to
+ * sleep) for each byte read and written.
+ *
+ * @param[in]  bus             SPI device to use
+ * @param[in]  read_channel    DMA channel to use for reading input
+ * @param[in]  write_channel   DMA channel to use for writing output
+ */
+void spi_set_dma_channel(spi_t bus, dma_channel_t read_channel,
+                         dma_channel_t write_channel);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is an updated pull request that adds DMA support in the ADC, I2C, and SPI drivers. If you would like, I can provide the original three commits (one each for ADC, I2C, and SPI). In this pull request, I have squashed those commits together.